### PR TITLE
Remove html_theme_path to fix search

### DIFF
--- a/refman/source/conf.py
+++ b/refman/source/conf.py
@@ -54,7 +54,7 @@ html_css_files = [
 pygments_style = 'sphinx'
 
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_theme_options = {
   'display_version': True,


### PR DESCRIPTION
- This changed fixed search on my machine - probably good to double check. 
- Solution taken from https://github.com/readthedocs/sphinx_rtd_theme/issues/1452, if this breaks anything (didn't on my end) then we can use the other fix of adding the following 
```python
extensions = [
    "sphinxcontrib.jquery",
]
```